### PR TITLE
[WIP]投稿に対するチャットの機能追加

### DIFF
--- a/components/Issue.vue
+++ b/components/Issue.vue
@@ -18,13 +18,15 @@
       <nav class="level is-mobile">
         <div class="level-left"></div>
         <div class="level-right">
-          <a class="level-item">
-            <a target="_blank" :href="`/issues/${issue['.key']}`" class="icon is-small"><i class="fa fa-eye"></i></a>
-          </a>
+          <i class="fa fa-eye" v-on:click="slideToggle" />
         </div>
       </nav>
-      <TheMessageTimeLine :issue="issue"/>
-      <TheMessagePostArea :issue="issue"/>
+      <transition>
+        <div class="message-list " v-if="open">
+          <TheMessageTimeLine :issue="issue"/>
+          <TheMessagePostArea :issue="issue"/>
+        </div>
+      </transition>
     </div>
   </li>
 </template>
@@ -36,12 +38,22 @@ import TheMessageTimeLine from '~/components/TheMessageTimeLine.vue'
 import TheMessagePostArea from '~/components/TheMessagePostArea.vue'
 
 export default {
+  data () {
+    return {
+      open: false
+    }
+  },
   props: {
     issue: Object
   },
   components: {
     TheMessageTimeLine,
     TheMessagePostArea
+  },
+  methods: {
+    slideToggle () {
+      this.open = !this.open
+    }
   },
   computed: {
     formattedPost () {

--- a/components/Issue.vue
+++ b/components/Issue.vue
@@ -17,7 +17,7 @@
         <div class="level-left"></div>
         <div class="level-right">
           <a class="level-item">
-            <a target="_blank" :href="`/posts/${issue['.key']}`" class="icon is-small"><i class="fa fa-eye"></i></a>
+            <a target="_blank" :href="`/issues/${issue['.key']}`" class="icon is-small"><i class="fa fa-eye"></i></a>
           </a>
         </div>
       </nav>

--- a/components/Issue.vue
+++ b/components/Issue.vue
@@ -11,6 +11,8 @@
           <strong>{{issue.user.name}}</strong>
           <br>
           <span v-html="formattedPost" />
+          <br>
+          <span v-html="formattedDate" />
         </p>
       </div>
       <nav class="level is-mobile">
@@ -44,6 +46,10 @@ export default {
   computed: {
     formattedPost () {
       return link(h(this.issue.body))
+    },
+    formattedDate () {
+      const d = new Date(this.issue.created_at)
+      return `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()} ${d.getHours()}:${d.getMinutes()}`
     }
   }
 }

--- a/components/Issue.vue
+++ b/components/Issue.vue
@@ -1,14 +1,14 @@
 <template lang="html">
-  <li class="media" v-if="post.user">
+  <li class="media" v-if="issue.user">
     <figure class="media-left">
       <p class="image is-64x64">
-        <img :src="post.user.icon">
+        <img :src="issue.user.icon">
       </p>
     </figure>
     <div class="media-content">
       <div class="content">
         <p>
-          <strong>{{post.user.name}}</strong>
+          <strong>{{issue.user.name}}</strong>
           <br>
           <span v-html="formattedPost" />
         </p>
@@ -17,10 +17,12 @@
         <div class="level-left"></div>
         <div class="level-right">
           <a class="level-item">
-            <a target="_blank" :href="`/posts/${post['.key']}`" class="icon is-small"><i class="fa fa-eye"></i></a>
+            <a target="_blank" :href="`/posts/${issue['.key']}`" class="icon is-small"><i class="fa fa-eye"></i></a>
           </a>
         </div>
       </nav>
+      <TheMessageTimeLine :issue="issue"/>
+      <TheMessagePostArea :issue="issue"/>
     </div>
   </li>
 </template>
@@ -28,14 +30,20 @@
 <script>
 import h from 'htmlspecialchars'
 import { link } from 'autolinker'
+import TheMessageTimeLine from '~/components/TheMessageTimeLine.vue'
+import TheMessagePostArea from '~/components/TheMessagePostArea.vue'
 
 export default {
   props: {
-    post: Object
+    issue: Object
+  },
+  components: {
+    TheMessageTimeLine,
+    TheMessagePostArea
   },
   computed: {
     formattedPost () {
-      return link(h(this.post.body))
+      return link(h(this.issue.body))
     }
   }
 }

--- a/components/Message.vue
+++ b/components/Message.vue
@@ -1,0 +1,38 @@
+<template lang="html">
+  <li class="media" v-if="message.user">
+    <figure class="media-left">
+      <p class="image is-64x64">
+        <img :src="message.user.icon">
+      </p>
+    </figure>
+    <div class="media-content">
+      <div class="content">
+        <p>
+          <strong>{{message.user.name}}</strong>
+          <br>
+          <span v-html="formattedPost" />
+        </p>
+      </div>
+    </div>
+  </li>
+</template>
+
+<script>
+import h from 'htmlspecialchars'
+import { link } from 'autolinker'
+
+export default {
+  props: {
+    message: Object
+  },
+  computed: {
+    formattedPost () {
+      console.log(this.message)
+      return link(h(this.message.body))
+    }
+  }
+}
+</script>
+
+<style lang="css">
+</style>

--- a/components/Message.vue
+++ b/components/Message.vue
@@ -11,6 +11,8 @@
           <strong>{{message.user.name}}</strong>
           <br>
           <span v-html="formattedPost" />
+          <br>
+          <span v-html="formattedDate" />
         </p>
       </div>
     </div>
@@ -28,6 +30,10 @@ export default {
   computed: {
     formattedPost () {
       return link(h(this.message.body))
+    },
+    formattedDate () {
+      const d = new Date(this.message.created_at)
+      return `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()} ${d.getHours()}:${d.getMinutes()}`
     }
   }
 }

--- a/components/Message.vue
+++ b/components/Message.vue
@@ -27,7 +27,6 @@ export default {
   },
   computed: {
     formattedPost () {
-      console.log(this.message)
       return link(h(this.message.body))
     }
   }

--- a/components/TheItemPostArea.vue
+++ b/components/TheItemPostArea.vue
@@ -1,0 +1,42 @@
+<template lang="html">
+  <form class="field is-grouped" @submit.prevent="doPost">
+    <p class="control is-expanded">
+      <input class="input" type="text" placeholder="Comment" v-model="body">
+    </p>
+    <p class="control">
+      <button class="button is-primary">
+        Post
+      </button>
+    </p>
+  </form>
+</template>
+
+<script>
+import { mapGetters } from 'vuex'
+
+export default {
+  data () {
+    return {
+      body: ''
+    }
+  },
+  props: {
+    post: Object
+  },
+  computed: {
+    ...mapGetters(['user'])
+  },
+  methods: {
+    async doPost () {
+      await this.$store.dispatch('ADD_COMMENT', {userId: this.user.uid, body: this.body, post: this.post['.key']})
+      this.body = ''
+    }
+  }
+}
+</script>
+
+<style scoped>
+.field {
+  margin-bottom: 16px;
+}
+</style>

--- a/components/TheMessagePostArea.vue
+++ b/components/TheMessagePostArea.vue
@@ -5,7 +5,7 @@
     </p>
     <p class="control">
       <button class="button is-primary">
-        issue
+        Post
       </button>
     </p>
   </form>

--- a/components/TheMessagePostArea.vue
+++ b/components/TheMessagePostArea.vue
@@ -5,7 +5,7 @@
     </p>
     <p class="control">
       <button class="button is-primary">
-        Post
+        issue
       </button>
     </p>
   </form>
@@ -21,14 +21,14 @@ export default {
     }
   },
   props: {
-    post: Object
+    issue: Object
   },
   computed: {
     ...mapGetters(['user'])
   },
   methods: {
     async doPost () {
-      await this.$store.dispatch('ADD_COMMENT', {userId: this.user.uid, body: this.body, post: this.post['.key']})
+      await this.$store.dispatch('ADD_MESSAGE', {userId: this.user.uid, body: this.body, issueId: this.issue['.key']})
       this.body = ''
     }
   }

--- a/components/TheMessageTimeLine.vue
+++ b/components/TheMessageTimeLine.vue
@@ -1,0 +1,24 @@
+<template>
+  <div class="timeline">
+    <ul>
+      <Message :message="message" v-for="message in messages(issue['.key'])" v-if="message.user" />
+    </ul>
+  </div>
+</template>
+
+<script>
+import Message from '~/components/message.vue'
+import { mapGetters } from 'vuex'
+
+export default {
+  components: {
+    Message
+  },
+  props: {
+    issue: Object
+  },
+  computed: {
+    ...mapGetters(['messages'])
+  }
+}
+</script>

--- a/components/TheMessageTimeLine.vue
+++ b/components/TheMessageTimeLine.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="timeline">
     <ul>
-      <Message :message="message" v-for="message in messages(issue['.key'])" v-if="message.user" />
+      <Message :message="message" :key="message['.key']" v-for="message in messages(issue['.key'])" v-if="message.user" />
     </ul>
   </div>
 </template>

--- a/components/TheTimeLine.vue
+++ b/components/TheTimeLine.vue
@@ -3,24 +3,24 @@
     <TheTimeLinePostArea v-if="user" />
     <ul class="posts">
       <transition-group name="post">
-        <Post class="post" :post="post" :key="post['.key']" v-for="post in posts" v-if="post.user" />
+        <Issue class="post" :issue="issue" :key="issue['.key']" v-for="issue in issues" v-if="issue.user" />
       </transition-group>
     </ul>
   </div>
 </template>
 
 <script>
-import Post from '~/components/Post.vue'
+import Issue from '~/components/Issue.vue'
 import { mapGetters } from 'vuex'
 import TheTimeLinePostArea from '~/components/TheTimeLinePostArea.vue'
 
 export default {
   components: {
-    Post,
+    Issue,
     TheTimeLinePostArea
   },
   computed: {
-    ...mapGetters(['user', 'posts'])
+    ...mapGetters(['user', 'issues'])
   }
 }
 </script>

--- a/components/TheTimeLinePostArea.vue
+++ b/components/TheTimeLinePostArea.vue
@@ -25,7 +25,7 @@ export default {
   },
   methods: {
     async doPost () {
-      await this.$store.dispatch('ADD_POST', {email: this.user.email, body: this.body})
+      await this.$store.dispatch('ADD_ISSUE', {userId: this.user.uid, body: this.body})
       this.body = ''
     }
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -32,14 +32,15 @@ export default {
       if (!this.user) user = await auth()
       await Promise.all([
         this.user ? Promise.resolve() : this.$store.dispatch('SET_CREDENTIAL', { user: user || null }),
-        this.posts.length ? Promise.resolve() : this.$store.dispatch('INIT_POSTS'),
-        this.users.length ? Promise.resolve() : this.$store.dispatch('INIT_USERS')
+        this.issues.length ? Promise.resolve() : this.$store.dispatch('INIT_ISSUES'),
+        this.users.length ? Promise.resolve() : this.$store.dispatch('INIT_USERS'),
+        this.messages ? Promise.resolve() : this.$store.dispatch('INIT_MESSAGES')
       ])
       this.isLoaded = true
     }
   },
   computed: {
-    ...mapGetters(['user', 'users', 'posts'])
+    ...mapGetters(['user', 'users', 'issues'])
   }
 }
 </script>

--- a/pages/issues/_id.vue
+++ b/pages/issues/_id.vue
@@ -1,18 +1,18 @@
 <template lang="html">
   <div class="container">
     <div class="columns">
-      <div class="column is-three-fifths is-offset-one-fifth" v-if="post && post.user">
-        <h1 class="title text-is-centered">{{post.user.name}}さんの投稿</h1>
+      <div class="column is-three-fifths is-offset-one-fifth" v-if="issue && issue.user">
+        <h1 class="title text-is-centered">{{issue.user.name}}さんの投稿</h1>
         <div class="card">
           <div class="card-content">
             <div class="media">
               <div class="media-left">
                 <figure class="image is-48x48">
-                  <img :src="post.user.icon">
+                  <img :src="issue.user.icon">
                 </figure>
               </div>
               <div class="media-content">
-                <strong>{{post.user.name}}</strong>
+                <strong>{{issue.user.name}}</strong>
               </div>
             </div>
 
@@ -44,9 +44,9 @@ export default {
   },
   computed: {
     formattedPost () {
-      return link(h(this.post ? this.post.body : ''))
+      return link(h(this.issue ? this.issue.body : ''))
     },
-    ...mapGetters(['post'])
+    ...mapGetters(['issue'])
   }
 }
 </script>

--- a/plugins/fetch.js
+++ b/plugins/fetch.js
@@ -10,6 +10,6 @@ export default async function ({ store }) {
       console.log(e)
     }
     await store.dispatch('SET_CREDENTIAL', { user: user || null })
-    await store.dispatch('INIT_POSTS')
+    await store.dispatch('INIT_ISSUES')
   }
 }

--- a/store/index.js
+++ b/store/index.js
@@ -34,8 +34,19 @@ const createStore = () => {
       },
       users: state => state.users,
       user: state => state.user,
-      messages: state => id => id ? state.messages[id] : state.messages,
-      message: state => state.message
+      messages: state => id => {
+        if (!state.messages[id]) return null
+        return Object.keys(state.messages[id]).map((key) => {
+          const message = state.messages[id][key]
+          message.user = state.users.find((user) => user['.key'] === message.from)
+          return message
+        })
+      },
+      message: state => {
+        const message = state.message
+        if (!message) return null
+        message.user = state.users.find((user) => user['.key'] === message.from)
+      }
     },
     mutations: {
       setCredential (state, { user }) {

--- a/store/index.js
+++ b/store/index.js
@@ -83,13 +83,15 @@ const createStore = () => {
       ADD_ISSUE: firebaseAction((ctx, { userId, body }) => {
         issuesRef.push({
           from: userId,
-          body
+          body,
+          created_at: new Date().getTime()
         })
       }),
       ADD_MESSAGE: firebaseAction((ctx, { userId, body, issueId }) => {
         messagesRef.child(issueId).push({
           from: userId,
-          body
+          body,
+          created_at: new Date().getTime()
         })
       }),
       callAuth () {

--- a/store/index.js
+++ b/store/index.js
@@ -5,6 +5,7 @@ import { firebaseMutations, firebaseAction } from 'vuexfire'
 const db = firebase.database()
 const usersRef = db.ref('/users')
 const postsRef = db.ref('/posts')
+const chatsRef = db.ref('/chats')
 const provider = new firebase.auth.TwitterAuthProvider()
 
 Vue.use(Vuex)
@@ -15,7 +16,8 @@ const createStore = () => {
       user: null,
       post: null,
       users: [],
-      posts: []
+      posts: [],
+      chats: []
     },
     getters: {
       posts: state => {
@@ -31,7 +33,8 @@ const createStore = () => {
         return post
       },
       users: state => state.users,
-      user: state => state.user
+      user: state => state.user,
+      chats: state => state.chats
     },
     mutations: {
       setCredential (state, { user }) {
@@ -62,9 +65,18 @@ const createStore = () => {
       INIT_POSTS: firebaseAction(({ bindFirebaseRef }) => {
         bindFirebaseRef('posts', postsRef)
       }),
+      INIT_CHATS: firebaseAction(({ bindFirebaseRef }) => {
+        bindFirebaseRef('chats', chatsRef)
+      }),
       ADD_POST: firebaseAction((ctx, { email, body }) => {
         postsRef.push({
           from: email,
+          body
+        })
+      }),
+      ADD_COMMENT: firebaseAction((ctx, { userId, body, post }) => {
+        chatsRef.child(post).push({
+          from: userId,
           body
         })
       }),

--- a/store/index.js
+++ b/store/index.js
@@ -69,7 +69,7 @@ const createStore = () => {
       },
       async INIT_SINGLE ({commit}, { id }) {
         const snapshot = await issuesRef.child(id).once('value')
-        commit('saveIssue', { issue: snapshot.val() })
+        commit('saveIssue', { issue: {...snapshot.val(), '.key': id} })
       },
       INIT_USERS: firebaseAction(({ bindFirebaseRef }) => {
         bindFirebaseRef('users', usersRef)


### PR DESCRIPTION
## やること
１つの投稿に対して、貸してほしい！とかメッセージを送りつける
チャット形式で会話ができる

## 変更点
コード
* 投稿を表すコンポーネントの名前をPostからIssueに変更
* 会話を表示するTheMessageTimeLine.vueを追加
* 会話の1つのメッセージを表すMessage.vueを追加
* 投稿に対してメッセージを送るフォーム、TheMessagePostArea.vueを追加
* 投稿やメッセージにタイムスタンプを追加

機能
* １つの投稿について会話ができる
* 会話は目のアイコンを押す事で表示の切り替えができる
* 新規ウインドウで開く機能をなくした

## 説明
データベースでメッセージは投稿のidで管理する
```
messages
 ∟{Issue.key}
    ∟{Message.key} : message
    ∟{Message.key} : message
    ∟{Message.key} : message
∟{Issue.key} 
```

## TODO
* [x] チャット
* [x] タイムスタンプの追加?
* [x] チャットの表示する箇所?

## 見てほしい箇所
* コンポーネントの命名が微妙な感じがするので、案があればお願いします
* cssは何も変更してないので、Postの名前変更にともなって変更する箇所が他にあれば
  